### PR TITLE
Configurable color spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Differences from the original repo
 - Training image names do not need to be prefixed by `Image`.
 - Added an `other` folder where you can dump images to train only the principal components.
 - Improved support for small datasets.
+- Add support for multiple colorspaces: RGB, BW (naive), BW (BT.709 Luma) and CIE XYZ.
 
 To Use
 ------

--- a/colorspaces.py
+++ b/colorspaces.py
@@ -1,0 +1,67 @@
+from PIL import Image
+import PIL.ImageOps
+
+class RgbConverter:
+
+    internalMode = "RGB"
+
+    @staticmethod
+    def apply(img):
+        return img
+
+    @staticmethod
+    def unapply(img):
+        return img
+
+class BwNaiveConverter:
+
+    internalMode = "RGB"
+
+    @staticmethod
+    def apply(img):
+        rgb2bw = (
+            0.33, 0.33, 0.33, 0,
+            0.33, 0.33, 0.33, 0,
+            0.33, 0.33, 0.33, 0 )
+        return img.convert("RGB", rgb2bw)
+
+    @staticmethod
+    def unapply(img):
+        return img
+
+class BwLumaConverter:
+
+    internalMode = "RGB"
+
+    @staticmethod
+    def apply(img):
+        rgb2bw = (
+            0.299, 0.587, 0.114, 0,
+            0.299, 0.587, 0.114, 0,
+            0.299, 0.587, 0.114, 0 )
+        return img.convert("RGB", rgb2bw)
+
+    @staticmethod
+    def unapply(img):
+        return img
+
+class XyzConverter:
+
+    internalMode = "RGB"
+
+    @staticmethod
+    def apply(img):
+        rgb2xyz = (
+            0.412453, 0.357580, 0.180423, 0,
+            0.212671, 0.715160, 0.072169, 0,
+            0.019334, 0.119193, 0.950227, 0 )
+        return img.convert("RGB", rgb2xyz)
+
+    @staticmethod
+    def unapply(img):
+        xyz2rgb = (
+            3.24048, -1.53715, -0.498536, 0,
+            -0.969255, 1.87599, 0.0415559, 0,
+            0.0556466, 0.204041, 1.05731, 0 )
+        return img.convert("RGB", xyz2rgb)
+

--- a/colorspaces.py
+++ b/colorspaces.py
@@ -36,9 +36,9 @@ class BwLumaConverter:
     @staticmethod
     def apply(img):
         rgb2bw = (
-            0.299, 0.587, 0.114, 0,
-            0.299, 0.587, 0.114, 0,
-            0.299, 0.587, 0.114, 0 )
+            0.2126, 0.7152, 0.0722, 0,
+            0.2126, 0.7152, 0.0722, 0,
+            0.2126, 0.7152, 0.0722, 0 )
         return img.convert("RGB", rgb2bw)
 
     @staticmethod

--- a/visuals.py
+++ b/visuals.py
@@ -13,76 +13,13 @@ import math
 import random
 import os
 from statistics import mean, median, standard_deviation, inverse_normal_cdf, interquartile_range
-
-class RgbConverter:
-
-    internalMode = "RGB"
-
-    @staticmethod
-    def apply(img):
-        return img
-
-    @staticmethod
-    def unapply(img):
-        return img
-
-class BwNaiveConverter:
-
-    internalMode = "RGB"
-
-    @staticmethod
-    def apply(img):
-        rgb2bw = (
-            0.33, 0.33, 0.33, 0,
-            0.33, 0.33, 0.33, 0,
-            0.33, 0.33, 0.33, 0 )
-        return img.convert("RGB", rgb2bw)
-
-    @staticmethod
-    def unapply(img):
-        return img
-
-class BwLumaConverter:
-
-    internalMode = "RGB"
-
-    @staticmethod
-    def apply(img):
-        rgb2bw = (
-            0.299, 0.587, 0.114, 0,
-            0.299, 0.587, 0.114, 0,
-            0.299, 0.587, 0.114, 0 )
-        return img.convert("RGB", rgb2bw)
-
-    @staticmethod
-    def unapply(img):
-        return img
-
-class XyzConverter:
-
-    internalMode = "RGB"
-
-    @staticmethod
-    def apply(img):
-        rgb2xyz = (
-            0.412453, 0.357580, 0.180423, 0,
-            0.212671, 0.715160, 0.072169, 0,
-            0.019334, 0.119193, 0.950227, 0 )
-        return img.convert("RGB", rgb2xyz)
-
-    @staticmethod
-    def unapply(img):
-        xyz2rgb = (
-            3.24048, -1.53715, -0.498536, 0,
-            -0.969255, 1.87599, 0.0415559, 0,
-            0.0556466, 0.204041, 1.05731, 0 )
-        return img.convert("RGB", xyz2rgb)
+import colorspaces
 
 N_COMPONENTS = 50
 N_COMPONENTS_TO_SHOW = 10
 N_DRESSES_TO_SHOW = 5
 N_NEW_DRESSES_TO_CREATE = 20
-CONVERTER = BwLumaConverter()
+CONVERTER = colorspaces.BwLumaConverter()
 
 # this is the size of all the Amazon.com images
 # If you are using a different source, change the size here

--- a/visuals.py
+++ b/visuals.py
@@ -14,24 +14,90 @@ import random
 import os
 from statistics import mean, median, standard_deviation, inverse_normal_cdf, interquartile_range
 
+class RgbConverter:
+
+    internalMode = "RGB"
+
+    @staticmethod
+    def apply(img):
+        return img
+
+    @staticmethod
+    def unapply(img):
+        return img
+
+class BwNaiveConverter:
+
+    internalMode = "RGB"
+
+    @staticmethod
+    def apply(img):
+        rgb2bw = (
+            0.33, 0.33, 0.33, 0,
+            0.33, 0.33, 0.33, 0,
+            0.33, 0.33, 0.33, 0 )
+        return img.convert("RGB", rgb2bw)
+
+    @staticmethod
+    def unapply(img):
+        return img
+
+class BwLumaConverter:
+
+    internalMode = "RGB"
+
+    @staticmethod
+    def apply(img):
+        rgb2bw = (
+            0.299, 0.587, 0.114, 0,
+            0.299, 0.587, 0.114, 0,
+            0.299, 0.587, 0.114, 0 )
+        return img.convert("RGB", rgb2bw)
+
+    @staticmethod
+    def unapply(img):
+        return img
+
+class XyzConverter:
+
+    internalMode = "RGB"
+
+    @staticmethod
+    def apply(img):
+        rgb2xyz = (
+            0.412453, 0.357580, 0.180423, 0,
+            0.212671, 0.715160, 0.072169, 0,
+            0.019334, 0.119193, 0.950227, 0 )
+        return img.convert("RGB", rgb2xyz)
+
+    @staticmethod
+    def unapply(img):
+        xyz2rgb = (
+            3.24048, -1.53715, -0.498536, 0,
+            -0.969255, 1.87599, 0.0415559, 0,
+            0.0556466, 0.204041, 1.05731, 0 )
+        return img.convert("RGB", xyz2rgb)
+
 N_COMPONENTS = 50
 N_COMPONENTS_TO_SHOW = 10
 N_DRESSES_TO_SHOW = 5
 N_NEW_DRESSES_TO_CREATE = 20
+CONVERTER = BwLumaConverter()
 
 # this is the size of all the Amazon.com images
 # If you are using a different source, change the size here
-STANDARD_SIZE = (200,260)
+STANDARD_SIZE = (200, 260)
 
 def img_to_array(filename):
     """takes a filename and turns it into a numpy array of RGB pixels"""
     img = Image.open(filename)
     img = img.resize(STANDARD_SIZE)
+    img = CONVERTER.apply(img)
     img = list(img.getdata())
     img = map(list, img)
     img = np.array(img)
-    s = img.shape[0] * img.shape[1]
-    img_wide = img.reshape(1, s)
+    shape = img.shape[0] * img.shape[1]
+    img_wide = img.reshape(1, shape)
     return img_wide[0]
 
 def makeFolder(directory):
@@ -200,9 +266,9 @@ def image_from_component_values(component):
     d = [(rescale(component[3 * i]),
           rescale(component[3 * i + 1]),
           rescale(component[3 * i + 2])) for i in range(n)]
-    im = Image.new('RGB',STANDARD_SIZE)
+    im = Image.new(CONVERTER.internalMode,STANDARD_SIZE)
     im.putdata(d)
-    return im
+    return CONVERTER.unapply(im)
 
 def makeRandomDress(saveName, liked):
     randomArr = []
@@ -220,8 +286,8 @@ def reconstructKnownDresses():
     directory = "results/recreatedDresses/"
     makeFolder(directory)
     for i in range(N_DRESSES_TO_SHOW):
-        Image.open(raw_data[i][2]).save(directory + str(i) + "_original.png")
         saveName = directory + str(i)
+        Image.open(raw_data[i][2]).save(saveName + "_original.png")
         reconstruct(i, saveName)
 
 def createNewDresses():


### PR DESCRIPTION
Add support for multiple color spaces for the intermediate representation, as RGB is usually a bad vector space (visually similar colors can get far apart).

The following conveters were added:
- RGBConverter: Does nothing. Even though the conceptual representation is not optimal, it's the only lossless conversion.
- BWNaiveConverter: A simple grayscale conversion by averaging the values of all channels. As expected, all color information is lost.
- BWLumaConverter: A grayscale conversion according to the ITU-R BT.709 luma transform.
- XyzConverter: A converter for CIE XYZ. Note that, while this conversion preserves color, it's still a lossy conversion.
